### PR TITLE
Fix issue with avatars missing after navigation between detail and list view

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -75,7 +75,7 @@
                 const allCustomizations = await getNamespaceData(CUSTOMIZATION_NAMESPACE)
 
                 // Loop through the rows
-                $('.repository-content div[data-id]').forEach((li) => {
+                $('.application-main div[data-id]').forEach((li) => {
                     if (!li.id.startsWith('issue_')) return
                     // Stretch the title area a bit in the Enterprise version
                     const titleLink = document.getElementById(`${li.id}_link`)

--- a/userscript/main.user.js
+++ b/userscript/main.user.js
@@ -41,7 +41,7 @@
             userCustomizations = userCustomizations || {}
 
             // Loop through the rows
-            $('.repository-content [data-id]').forEach((row) => {
+            $('.application-main [data-id]').forEach((row) => {
                 const authorTag = row.querySelector('.opened-by a')
                 const authorName = authorTag.innerHTML
 


### PR DESCRIPTION
As GitHub now dynamically changes the content when navigating between the pages, the class "repository-content" is sometimes not available when arriving on the list page. For this reason the extension is not able to process the page content and add the avatars. I simply replaced the "repository-content" class in the selector for the rows with one at a higher level which is not replaced "application-main".