### PR TITLE
Exlcude Issues Page

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,9 +1,14 @@
 chrome.tabs.onUpdated.addListener(async function (tabId, changeInfo, tab) {
-    if (changeInfo.status !== 'complete' || !tab || !tab.url || tab.url === 'chrome://newtab/') {
+    if (
+        changeInfo.status !== 'complete' ||
+        !tab ||
+        !tab.url ||
+        !tab.url.startsWith('https://github.com')
+    ) {
         return
     }
 
-    if (tab.url.startsWith('https://github.com')) {
+    if (tab.url.includes('/pulls') || tab.url.includes('/issues')) {
         chrome.scripting.insertCSS({
             target: { tabId },
             files: ['stylesheet.css'],

--- a/extension/content.js
+++ b/extension/content.js
@@ -11,7 +11,8 @@
     const CUSTOMIZATION_NAMESPACE = '__Avatar_customizations__'
     const selectorEnum = {
         LIST: '#js-issues-toolbar',
-        DETAILS: '#discussion_bucket',
+        PULL_REQUESTS: '#js-issues-toolbar',
+        ISSUES: '#repository-results',
     }
     // Maximum number of avatars that can be shown simultaneously on the same PR/issue
     const MAX_AVATARS = 2
@@ -21,13 +22,21 @@
             // Element that signals that we are on such or such page
             let landmarkElement
 
-            const urlData = getInfoFromUrl()
+            const { section, itemId } = getInfoFromUrl()
+            if (itemId) {
+                return
+            }
+            if (section === 'issues') {
+                // The page was rewritten in January 2025 by the Github team and tags/ids are now completely different than the Pull Requests page
+                // Not yet supported by this extension
+                return
+            }
 
-            if (isListPage(urlData)) {
+            if (section === 'pulls') {
                 // -------------------------------
                 // PULL REQUESTS / ISSUES LIST PAGE
                 // -------------------------------
-                landmarkElement = await waitForUmarkedElement(selectorEnum.LIST)
+                landmarkElement = await waitForUmarkedElement(selectorEnum.PULL_REQUESTS)
                 markElement(landmarkElement)
 
                 const allCustomizations = await getNamespaceData(CUSTOMIZATION_NAMESPACE)
@@ -81,15 +90,7 @@
                     }
                 })
             }
-        } catch (e) {
-            // console.log('🙉', e)
-        }
-    }
-
-    /** Check page url and returns whether or not we are in a list page (pull request/issues lists )*/
-    function isListPage(urlData) {
-        const { section, itemId } = urlData || getInfoFromUrl()
-        return section === 'pulls' || (section === 'issues' && !itemId)
+        } catch (e) {}
     }
 
     async function getNamespaceData(namespace) {
@@ -179,7 +180,7 @@
      * @return {Promise}
      */
     function waitFor(selector, options = {}) {
-        const SEARCH_THRESHOLD = 80
+        const SEARCH_THRESHOLD = 50
         const INTERVAL = 100
         const { condition } = options
         let iterationCount = 0

--- a/extension/tests/e2e.test.js
+++ b/extension/tests/e2e.test.js
@@ -2,7 +2,7 @@ const puppeteer = require('puppeteer')
 
 const EXTENSION_PATH = './extension'
 const PR_URL = 'https://github.com/facebook/react/pulls'
-const ISSUES_URL = 'https://github.com/facebook/react/issues'
+// const ISSUES_URL = 'https://github.com/facebook/react/issues'
 const MAX_PER_PAGE = 25
 
 let browser
@@ -17,11 +17,13 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-    await browser.close()
+    if (browser?.close) {
+        await browser.close()
+    }
     browser = undefined
 })
 
-test('displays avatars for all pull requests', async () => {
+test.only('displays avatars for all pull requests', async () => {
     const page = await browser.newPage()
 
     await page.goto(`${PR_URL}?is%3Aclosed`)
@@ -33,38 +35,38 @@ test('displays avatars for all pull requests', async () => {
     expect(avatars.length).toBe(MAX_PER_PAGE)
 })
 
-test('displays avatars for all issues', async () => {
-    const page = await browser.newPage()
+// test('displays avatars for all issues', async () => {
+//     const page = await browser.newPage()
 
-    await page.goto(`${ISSUES_URL}?is%3Aclosed`)
+//     await page.goto(`${ISSUES_URL}?is%3Aclosed`)
 
-    await page.waitForSelector('[data-testid="avatar-image"]')
+//     await page.waitForSelector('[data-testid="avatar-image"]')
 
-    const avatars = await page.$$('[data-testid="avatar-image"]')
+//     const avatars = await page.$$('[data-testid="avatar-image"]')
 
-    expect(avatars.length).toBe(MAX_PER_PAGE)
-})
+//     expect(avatars.length).toBe(MAX_PER_PAGE)
+// })
 
-describe('when navigating', () => {
-    test('displays avatars', async () => {
-        const page = await browser.newPage()
+// describe('when navigating', () => {
+//     test('displays avatars', async () => {
+//         const page = await browser.newPage()
 
-        await page.goto(`${PR_URL}?is%3Aclosed`)
+//         await page.goto(`${PR_URL}?is%3Aclosed`)
 
-        // Wait for avatars to load
-        await page.waitForSelector('[data-testid="avatar-image"]')
+//         // Wait for avatars to load
+//         await page.waitForSelector('[data-testid="avatar-image"]')
 
-        // Navigate to the Issues page by clicking the tab
-        await page.click('#issues-tab')
-        await page.waitForNavigation({ waitUntil: 'networkidle2' })
+//         // Navigate to the Issues page by clicking the tab
+//         await page.click('#issues-tab')
+//         await page.waitForNavigation({ waitUntil: 'networkidle2' })
 
-        // Ensure the Issues page has loaded properly
-        const inputValue = await page.$eval('#js-issues-search', (input) => input.value)
-        expect(inputValue).toContain('is:issue')
+//         // Ensure the Issues page has loaded properly
+//         const inputValue = await page.$eval('#js-issues-search', (input) => input.value)
+//         expect(inputValue).toContain('is:issue')
 
-        // Wait for avatars to load
-        // React is such a big repo that there always will be at least one issue opened
-        const avatar = await page.waitForSelector('[data-testid="avatar-image"]')
-        expect(avatar).not.toBe(null)
-    })
-})
+//         // Wait for avatars to load
+//         // React is such a big repo that there always will be at least one issue opened
+//         const avatar = await page.waitForSelector('[data-testid="avatar-image"]')
+//         expect(avatar).not.toBe(null)
+//     })
+// })


### PR DESCRIPTION
The page was rewritten in January 2025 by the Github team and tags/ids are now completely different than for the Pull Requests page. 
Excluding the page for the moment being.